### PR TITLE
add test for handlertorch

### DIFF
--- a/config/ruff.toml
+++ b/config/ruff.toml
@@ -63,6 +63,7 @@ ignore = [
     "PLR2004",  # Magic value used in comparison
     "S101",  # Use of assert detected
 ]
+"tests/unittest_*.py" = ["ALL"]
 
 [lint.flake8-quotes]
 docstring-quotes = "double"

--- a/config/ruff.toml
+++ b/config/ruff.toml
@@ -63,6 +63,8 @@ ignore = [
     "PLR2004",  # Magic value used in comparison
     "S101",  # Use of assert detected
 ]
+
+# TODO temporary just until all unittests are passed to unittest
 "tests/unittest_*.py" = ["ALL"]
 
 [lint.flake8-quotes]

--- a/tests/test_csv_loader.py
+++ b/tests/test_csv_loader.py
@@ -14,6 +14,10 @@ class DataCsvLoader:
     This class initializes CsvLoader objects with given csv data and stores expected
     values for testing purposes.
 
+    Args:
+        filename (str): Path to the CSV file.
+        experiment (Any): Experiment class to be instantiated.
+
     Attributes:
         experiment: An experiment instance to process the data.
         csv_path (str): Absolute path to the CSV file.
@@ -23,12 +27,6 @@ class DataCsvLoader:
     """
 
     def __init__(self, filename: str, experiment: Any):
-        """Initialize DataCsvLoader with a CSV file and experiment type.
-
-        Args:
-            filename (str): Path to the CSV file.
-            experiment (Any): Experiment class to be instantiated.
-        """
         self.experiment = experiment()
         self.csv_path = os.path.abspath(filename)
         self.csv_loader = CsvLoader(self.experiment, self.csv_path)

--- a/tests/test_csv_processing.py
+++ b/tests/test_csv_processing.py
@@ -14,6 +14,10 @@ class DataCsvProcessing:
 
     One can use this class to create the data fixtures.
 
+    Args:
+        filename (str): The path to the CSV file.
+        experiment (type): The class type of the experiment to be instantiated.
+
     Attributes:
         experiment (Experiment): An instance of the experiment class.
         csv_path (str): The absolute path to the CSV file.
@@ -21,10 +25,6 @@ class DataCsvProcessing:
         data_length (int or None): The length of the data. Initialized to None.
         expected_split (List[int] or None): The expected split values after adding split. Initialized to None.
         expected_transformed_values (Any or None): The expected values after split and transformation. Initialized to None.
-
-    Args:
-        filename (str): The path to the CSV file.
-        experiment (type): The class type of the experiment to be instantiated.
     """
 
     def __init__(self, filename: str, experiment: Any):

--- a/tests/test_csv_processing.py
+++ b/tests/test_csv_processing.py
@@ -63,7 +63,8 @@ def dna_test_data_long():
 def dna_test_data_long_shuffled():
     """This stores the shuffled long dna test csv"""
     data = DataCsvProcessing(
-        "tests/test_data/dna_experiment/test_shuffling_long_shuffled.csv", ProtDnaToFloatExperiment
+        "tests/test_data/dna_experiment/test_shuffling_long_shuffled.csv",
+        ProtDnaToFloatExperiment,
     )
     data.data_length = 1000
     return data

--- a/tests/test_data_transformers.py
+++ b/tests/test_data_transformers.py
@@ -26,7 +26,7 @@ class DataTransformerTest:
         expected_multiple_outputs: The expected outputs for the multiple inputs.
     """
 
-    def __init__( # noqa: D107
+    def __init__(  # noqa: D107
         self,
         transformer: AbstractDataTransformer,
         params: dict,

--- a/tests/test_handlertorch.py
+++ b/tests/test_handlertorch.py
@@ -27,6 +27,7 @@ class TorchTestData:
         expected_label_shape: Expected shape of label tensors.
         expected_item_shape: Expected shape of individual items.
     """
+
     def __init__(self, filename: str, experiment: Any):
         self.experiment = experiment()
         self.csv_path = os.path.abspath(filename)
@@ -201,5 +202,6 @@ class TestGetItem:
                 slice_len = idx.stop - idx.start
                 expected_item_shape = [slice_len] + expected_item_shape
             assert dict_items[key].shape == torch.Size(expected_item_shape)
+
 
 # TODO add test for titanic dataset

--- a/tests/test_handlertorch.py
+++ b/tests/test_handlertorch.py
@@ -9,11 +9,28 @@ from src.stimulus.data.handlertorch import TorchDataset
 
 
 class TorchTestData:
+    """Test data container for TorchDataset tests.
+
+    This class handles the initialization and storage of test data for various
+    experiments using TorchDataset.
+
+    Args:
+        filename: Path to the CSV file containing test data.
+        experiment: Experiment class to be instantiated.
+
+    Attributes:
+        experiment: Instantiated experiment object.
+        csv_path: Absolute path to the test CSV file.
+        torch_dataset: Instantiated TorchDataset object.
+        expected_len: Expected length of the dataset.
+        expected_input_shape: Expected shape of input tensors.
+        expected_label_shape: Expected shape of label tensors.
+        expected_item_shape: Expected shape of individual items.
+    """
     def __init__(self, filename: str, experiment: Any):
         self.experiment = experiment()
         self.csv_path = os.path.abspath(filename)
         self.torch_dataset = TorchDataset(self.csv_path, self.experiment)
-        print(self.torch_dataset.input)
         self.expected_len = None
         self.expected_input_shape = None
         self.expected_label_shape = None
@@ -22,6 +39,11 @@ class TorchTestData:
 
 @pytest.fixture
 def dna_test_data():
+    """Fixture providing test data for DNA experiment.
+
+    Returns:
+        TorchTestData: Configured test data for DNA experiments.
+    """
     data = TorchTestData("tests/test_data/dna_experiment/test.csv", DnaToFloatExperiment)
     data.expected_len = 2
     data.expected_input_shape = {"hello": [2, 16, 4]}
@@ -32,6 +54,11 @@ def dna_test_data():
 
 @pytest.fixture
 def dna_test_data_with_float():
+    """Fixture providing test data for DNA experiment with float values.
+
+    Returns:
+        TorchTestData: Configured test data for DNA experiments with float values.
+    """
     data = TorchTestData("tests/test_data/dna_experiment/test_unequal_dna_float.csv", DnaToFloatExperiment)
     data.expected_len = 4
     data.expected_input_shape = {"hello": [4, 31, 4]}
@@ -42,6 +69,11 @@ def dna_test_data_with_float():
 
 @pytest.fixture
 def prot_dna_test_data():
+    """Fixture providing test data for Protein-DNA experiment.
+
+    Returns:
+        TorchTestData: Configured test data for Protein-DNA experiments.
+    """
     data = TorchTestData("tests/test_data/prot_dna_experiment/test.csv", ProtDnaToFloatExperiment)
     data.expected_len = 2
     data.expected_input_shape = {"hello": [2, 16, 4], "bonjour": [2, 15, 20]}
@@ -59,6 +91,12 @@ def prot_dna_test_data():
     ],
 )
 def test_data_length(request, fixture_name: str):
+    """Test if dataset length matches expected length.
+
+    Args:
+        request: Pytest fixture request.
+        fixture_name: Name of the fixture to test.
+    """
     data = request.getfixturevalue(fixture_name)
     assert len(data.torch_dataset) == data.expected_len
 
@@ -72,21 +110,47 @@ def test_data_length(request, fixture_name: str):
     ],
 )
 class TestDictOfTensors:
+    """Test that torch dataset properly parses dictionaries of tensors."""
+
     def test_input_is_dict(self, request, fixture_name: str):
+        """Test if input is a dictionary.
+
+        Args:
+            request: Pytest fixture request.
+            fixture_name: Name of the fixture to test.
+        """
         data = request.getfixturevalue(fixture_name)
         assert isinstance(data.torch_dataset.input, Dict)
 
     def test_label_is_dict(self, request, fixture_name: str):
+        """Test if label is a dictionary.
+
+        Args:
+            request: Pytest fixture request.
+            fixture_name: Name of the fixture to test.
+        """
         data = request.getfixturevalue(fixture_name)
         assert isinstance(data.torch_dataset.label, Dict)
 
     def test_input_tensor_shape(self, request, fixture_name: str):
+        """Test if input tensor shapes match expected shapes.
+
+        Args:
+            request: Pytest fixture request.
+            fixture_name: Name of the fixture to test.
+        """
         data = request.getfixturevalue(fixture_name)
         for key, tensor in data.torch_dataset.input.items():
             assert isinstance(tensor, torch.Tensor)
             assert tensor.shape == torch.Size(data.expected_input_shape[key])
 
     def test_label_tensor_shape(self, request, fixture_name: str):
+        """Test if label tensor shapes match expected shapes.
+
+        Args:
+            request: Pytest fixture request.
+            fixture_name: Name of the fixture to test.
+        """
         data = request.getfixturevalue(fixture_name)
         for key, tensor in data.torch_dataset.label.items():
             assert isinstance(tensor, torch.Tensor)
@@ -105,7 +169,16 @@ class TestDictOfTensors:
     ],
 )
 class TestGetItem:
+    """Test suite for dataset item retrieval."""
+
     def test_is_dict(self, request, fixture_name: str, idx: Any):
+        """Test if retrieved items are dictionaries.
+
+        Args:
+            request: Pytest fixture request.
+            fixture_name: Name of the fixture to test.
+            idx: Index or slice to retrieve items.
+        """
         data = request.getfixturevalue(fixture_name)
         x, y, meta = data.torch_dataset[idx]
         assert isinstance(x, dict)
@@ -113,6 +186,13 @@ class TestGetItem:
         assert isinstance(meta, dict)
 
     def test_get_correct_items(self, request, fixture_name: str, idx: Any):
+        """Test if retrieved items have correct shapes.
+
+        Args:
+            request: Pytest fixture request.
+            fixture_name: Name of the fixture to test.
+            idx: Index or slice to retrieve items.
+        """
         data = request.getfixturevalue(fixture_name)
         x, y, meta = data.torch_dataset[idx]
         dict_items = {**x, **y, **meta}
@@ -121,6 +201,5 @@ class TestGetItem:
                 slice_len = idx.stop - idx.start
                 expected_item_shape = [slice_len] + expected_item_shape
             assert dict_items[key].shape == torch.Size(expected_item_shape)
-
 
 # TODO add test for titanic dataset

--- a/tests/test_handlertorch.py
+++ b/tests/test_handlertorch.py
@@ -156,7 +156,6 @@ class TorchTestData:
         return len(data)
 
 
-# Replace individual fixtures with a parametrized fixture
 @pytest.fixture(params=[
     ("tests/test_data/dna_experiment/test.csv", DnaToFloatExperiment, {
         "length": 2,
@@ -175,14 +174,27 @@ class TorchTestData:
     })
 ])
 def test_data(request) -> TorchTestData:
-    """Parametrized fixture providing test data for all experiment types."""
+    """Parametrized fixture providing test data for all experiment types.
+
+    This parametrized fixture contain tuples of (filename, experiment_class, expected_values)
+    for each test data file. It loads the test data and initializes the TorchTestData object.
+    By parametrizing the fixture, we can run the same tests on different datasets, without
+    the need for individual fixtures or duplicate the code.
+
+    Args:
+        request: Pytest fixture request object containing parametrized test data.
+
+    Returns:
+        TorchTestData: A test data object containing the initialized torch dataset
+            and the expected values for the dataset.
+    """
     filename, experiment_class, expected_values = request.param
     data = TorchTestData(filename, experiment_class)
     data.expected_values = expected_values
     return data
 
 
-def validate_expected_values(test_data) -> None:
+def test_expected_values(test_data) -> None:
     """Validate the expected values are properly defined.
     
     Since we defined the expected values by computing them from the test data with

--- a/tests/test_handlertorch.py
+++ b/tests/test_handlertorch.py
@@ -1,9 +1,10 @@
 import os
-import pytest
-import torch
 from typing import Any, Dict
 
-from src.stimulus.data.experiments import DnaToFloatExperiment, ProtDnaToFloatExperiment, TitanicExperiment
+import pytest
+import torch
+
+from src.stimulus.data.experiments import DnaToFloatExperiment, ProtDnaToFloatExperiment
 from src.stimulus.data.handlertorch import TorchDataset
 
 
@@ -71,7 +72,6 @@ def test_data_length(request, fixture_name: str):
     ],
 )
 class TestDictOfTensors:
-
     def test_input_is_dict(self, request, fixture_name: str):
         data = request.getfixturevalue(fixture_name)
         assert isinstance(data.torch_dataset.input, Dict)
@@ -85,7 +85,7 @@ class TestDictOfTensors:
         for key, tensor in data.torch_dataset.input.items():
             assert isinstance(tensor, torch.Tensor)
             assert tensor.shape == torch.Size(data.expected_input_shape[key])
-    
+
     def test_label_tensor_shape(self, request, fixture_name: str):
         data = request.getfixturevalue(fixture_name)
         for key, tensor in data.torch_dataset.label.items():
@@ -105,7 +105,6 @@ class TestDictOfTensors:
     ],
 )
 class TestGetItem:
-
     def test_is_dict(self, request, fixture_name: str, idx: Any):
         data = request.getfixturevalue(fixture_name)
         x, y, meta = data.torch_dataset[idx]
@@ -122,5 +121,6 @@ class TestGetItem:
                 slice_len = idx.stop - idx.start
                 expected_item_shape = [slice_len] + expected_item_shape
             assert dict_items[key].shape == torch.Size(expected_item_shape)
+
 
 # TODO add test for titanic dataset

--- a/tests/test_handlertorch.py
+++ b/tests/test_handlertorch.py
@@ -16,7 +16,7 @@ class TorchTestData:
     This class handles the loading and preprocessing of test data for PyTorch-based experiments.
     It also provides the expected data content and shapes, by loading the data in alternative ways:
     it reads data from a CSV file, encodes and pads the input/label data according to the
-    experiment specifications. 
+    experiment specifications.
 
     Args:
         filename (str): Path to the CSV file containing the test data.
@@ -35,6 +35,7 @@ class TorchTestData:
         hardcoded_expected_input_shape (dict): Expected shapes of input tensors.
         hardcoded_expected_label_shape (dict): Expected shapes of label tensors.
     """
+
     def __init__(self, filename: str, experiment: Any):
         # load test data
         self.experiment = experiment()
@@ -45,8 +46,8 @@ class TorchTestData:
         self.expected_input = self.get_encoded_padded_category("input")
         self.expected_label = self.get_encoded_padded_category("label")
         self.expected_len = self.get_data_length()
-        self.expected_input_shape = {k: v.shape for k,v in self.expected_input.items()}
-        self.expected_label_shape = {k: v.shape for k,v in self.expected_label.items()}
+        self.expected_input_shape = {k: v.shape for k, v in self.expected_input.items()}
+        self.expected_label_shape = {k: v.shape for k, v in self.expected_label.items()}
 
         # provide options for hardcoded expected values
         # they must be the same as the expected values above, otherwise the tests will fail
@@ -54,7 +55,7 @@ class TorchTestData:
         self.hardcoded_expected_len = None
         self.hardcoded_expected_input_shape = None
         self.hardcoded_expected_label_shape = None
-    
+
     def get_encoded_padded_category(self, category: str):
         """Retrieves encoded data for a specific category from a CSV file.
 
@@ -84,7 +85,6 @@ class TorchTestData:
             current_category = colname.split(":")[1]
             current_datatype = colname.split(":")[2]
             if current_category == category:
-
                 # get and encode data into list of tensors
                 tmp = self.experiment.get_function_encode_all(current_datatype)(data[colname].to_list())
 
@@ -98,10 +98,10 @@ class TorchTestData:
                 # convert list into tensor
                 elif category == "label":
                     tmp = torch.tensor(tmp)
-                
+
                 columns[current_name] = tmp
         return columns
-    
+
     def get_data_length(self):
         """Returns the length of the CSV data.
 
@@ -121,6 +121,7 @@ class TorchTestData:
 @pytest.fixture
 def dna_test_data():
     """Fixture providing test data for DNA experiment.
+
     Returns:
         TorchTestData: Configured test data for DNA experiments.
     """
@@ -134,6 +135,7 @@ def dna_test_data():
 @pytest.fixture
 def dna_test_data_with_float():
     """Fixture providing test data for DNA experiment with float values.
+
     Returns:
         TorchTestData: Configured test data for DNA experiments with float values.
     """
@@ -147,6 +149,7 @@ def dna_test_data_with_float():
 @pytest.fixture
 def prot_dna_test_data():
     """Fixture providing test data for Protein-DNA experiment.
+
     Returns:
         TorchTestData: Configured test data for Protein-DNA experiments.
     """
@@ -167,6 +170,7 @@ def prot_dna_test_data():
 )
 def test_data_length(request, fixture_name: str):
     """Test if dataset length matches expected length.
+
     Args:
         request: Pytest fixture request.
         fixture_name: Name of the fixture to test.
@@ -193,9 +197,10 @@ class TestDictOfTensors:
     3. Tensor shapes match expected dimensions
     4. Tensor contents match expected values
     """
-    
+
     def test_input_is_dict(self, request, fixture_name: str):
         """Test if input is a dictionary.
+
         Args:
             request: Pytest fixture request.
             fixture_name: Name of the fixture to test.
@@ -205,6 +210,7 @@ class TestDictOfTensors:
 
     def test_label_is_dict(self, request, fixture_name: str):
         """Test if label is a dictionary.
+
         Args:
             request: Pytest fixture request.
             fixture_name: Name of the fixture to test.

--- a/tests/test_handlertorch.py
+++ b/tests/test_handlertorch.py
@@ -97,8 +97,11 @@ class TestDictOfTensors:
     "fixture_name,idx",
     [
         ("dna_test_data", 0),
+        ("dna_test_data", slice(0, 2)),
         ("dna_test_data_with_float", 0),
+        ("dna_test_data_with_float", slice(0, 2)),
         ("prot_dna_test_data", 0),
+        ("prot_dna_test_data", slice(0, 2)),
     ],
 )
 class TestGetItem:

--- a/tests/test_handlertorch.py
+++ b/tests/test_handlertorch.py
@@ -305,4 +305,4 @@ class TestTorchDataset:
             assert torch.equal(dict_items[key], expected_tensor)
         
 
-# Remove redundant test classes and consolidate tests
+# TODO add tests for titanic dataset

--- a/tests/test_handlertorch.py
+++ b/tests/test_handlertorch.py
@@ -1,3 +1,38 @@
+"""Tests for the PyTorch data handling functionality.
+
+This module contains comprehensive test suites for verifying the proper functioning
+of PyTorch dataset handling, particularly focusing on DNA and Protein-DNA experiments.
+It includes tests for data loading, tensor shape verification, and content validation.
+
+The test suite is organized into several components:
+- TorchTestData: A class that handles test data loading and preprocessing
+- Fixtures for different types of experimental data
+- Test suites for verifying dataset properties and tensor handling
+
+Key test areas include:
+- Dataset length verification
+- Dictionary and tensor structure validation
+- Tensor shape verification
+- Tensor content validation
+- Dataset indexing and slicing functionality
+
+Test Fixtures:
+    dna_test_data: Basic DNA experiment test data
+    dna_test_data_with_float: DNA experiment test data with float values
+    prot_dna_test_data: Protein-DNA experiment test data
+
+Test Classes:
+    TestDictOfTensors: Verifies proper parsing of datasets into tensor dictionaries
+    TestGetItem: Validates the dataset indexing functionality
+
+Dependencies:
+    - pytest
+    - torch
+    - polars
+    - os
+    - typing
+"""
+
 import os
 from typing import Any, Dict
 

--- a/tests/test_handlertorch.py
+++ b/tests/test_handlertorch.py
@@ -1,85 +1,159 @@
 import os
 from typing import Any, Dict
 
+import polars as pl
 import pytest
 import torch
+from torch.nn.utils.rnn import pad_sequence
 
 from src.stimulus.data.experiments import DnaToFloatExperiment, ProtDnaToFloatExperiment
 from src.stimulus.data.handlertorch import TorchDataset
 
 
 class TorchTestData:
-    """Test data container for TorchDataset tests.
+    """It declares the data for the tests, and the expected data content and shapes.
 
-    This class handles the initialization and storage of test data for various
-    experiments using TorchDataset.
+    This class handles the loading and preprocessing of test data for PyTorch-based experiments.
+    It also provides the expected data content and shapes, by loading the data in alternative ways:
+    it reads data from a CSV file, encodes and pads the input/label data according to the
+    experiment specifications. 
 
     Args:
-        filename: Path to the CSV file containing test data.
-        experiment: Experiment class to be instantiated.
+        filename (str): Path to the CSV file containing the test data.
+        experiment (Any): The experiment class that defines data processing methods.
 
     Attributes:
-        experiment: Instantiated experiment object.
-        csv_path: Absolute path to the test CSV file.
-        torch_dataset: Instantiated TorchDataset object.
-        expected_len: Expected length of the dataset.
-        expected_input_shape: Expected shape of input tensors.
-        expected_label_shape: Expected shape of label tensors.
-        expected_item_shape: Expected shape of individual items.
+        experiment: An instance of the experiment class that defines data processing methods.
+        csv_path (str): Absolute path to the CSV file containing the test data.
+        torch_dataset (TorchDataset): The PyTorch dataset created from the CSV file.
+        expected_input (dict): Dictionary containing encoded and padded input data.
+        expected_label (dict): Dictionary containing encoded label data.
+        expected_len (int): Number of rows in the CSV data.
+        expected_input_shape (dict): Dictionary containing shapes of input tensors.
+        expected_label_shape (dict): Dictionary containing shapes of label tensors.
+        hardcoded_expected_len (int): Expected number of rows in the CSV data.
+        hardcoded_expected_input_shape (dict): Expected shapes of input tensors.
+        hardcoded_expected_label_shape (dict): Expected shapes of label tensors.
     """
-
     def __init__(self, filename: str, experiment: Any):
+        # load test data
         self.experiment = experiment()
         self.csv_path = os.path.abspath(filename)
         self.torch_dataset = TorchDataset(self.csv_path, self.experiment)
-        self.expected_len = None
-        self.expected_input_shape = None
-        self.expected_label_shape = None
-        self.expected_item_shape = None
+
+        # get expected data
+        self.expected_input = self.get_encoded_padded_category("input")
+        self.expected_label = self.get_encoded_padded_category("label")
+        self.expected_len = self.get_data_length()
+        self.expected_input_shape = {k: v.shape for k,v in self.expected_input.items()}
+        self.expected_label_shape = {k: v.shape for k,v in self.expected_label.items()}
+
+        # provide options for hardcoded expected values
+        # they must be the same as the expected values above, otherwise the tests will fail
+        # this is for extra verification
+        self.hardcoded_expected_len = None
+        self.hardcoded_expected_input_shape = None
+        self.hardcoded_expected_label_shape = None
+    
+    def get_encoded_padded_category(self, category: str):
+        """Retrieves encoded data for a specific category from a CSV file.
+
+        This method reads a CSV file and processes columns that match the specified category.
+        Each column in the CSV is expected to follow the format 'name:category:datatype'.
+        The data from matching columns is encoded using the appropriate encoding function
+        based on the datatype. The encoded data is then padded to the same length.
+
+        Args:
+            category (str): The category to filter columns by.
+
+        Returns:
+            dict: A dictionary where keys are column names (without category and datatype)
+                  and values are the encoded data for that column.
+
+        Example:
+            If CSV contains a column "stimulus:visual:str", and category="visual",
+            the returned dict will have "stimulus" as a key with its encoded values.
+        """
+        # read data
+        data = pl.read_csv(self.csv_path)
+
+        # filter columns by category
+        columns = {}
+        for colname in data.columns:
+            current_name = colname.split(":")[0]
+            current_category = colname.split(":")[1]
+            current_datatype = colname.split(":")[2]
+            if current_category == category:
+
+                # get and encode data into list of tensors
+                tmp = self.experiment.get_function_encode_all(current_datatype)(data[colname].to_list())
+
+                # pad sequences to the same length
+                # NOTE that this is hardcoded to pad with 0
+                # so it will only work for tests where padding with 0 is expected
+                if category == "input":
+                    tmp = [torch.tensor(item) for item in tmp]
+                    tmp = pad_sequence(tmp, batch_first=True, padding_value=0)
+
+                # convert list into tensor
+                elif category == "label":
+                    tmp = torch.tensor(tmp)
+                
+                columns[current_name] = tmp
+        return columns
+    
+    def get_data_length(self):
+        """Returns the length of the CSV data.
+
+        This method reads a CSV file from the specified path and returns the number of rows in the data.
+
+        Returns:
+            int: The number of rows in the CSV file.
+
+        Raises:
+            FileNotFoundError: If the CSV file does not exist at the specified path.
+            pl.exceptions.NoDataError: If the CSV file is empty.
+        """
+        data = pl.read_csv(self.csv_path)
+        return len(data)
 
 
 @pytest.fixture
 def dna_test_data():
     """Fixture providing test data for DNA experiment.
-
     Returns:
         TorchTestData: Configured test data for DNA experiments.
     """
     data = TorchTestData("tests/test_data/dna_experiment/test.csv", DnaToFloatExperiment)
-    data.expected_len = 2
-    data.expected_input_shape = {"hello": [2, 16, 4]}
-    data.expected_label_shape = {"hola": [2]}
-    data.expected_item_shape = {"hello": [16, 4]}
+    data.hardcoded_expected_len = 2
+    data.hardcoded_expected_input_shape = {"hello": [2, 16, 4]}
+    data.hardcoded_expected_label_shape = {"hola": [2]}
     return data
 
 
 @pytest.fixture
 def dna_test_data_with_float():
     """Fixture providing test data for DNA experiment with float values.
-
     Returns:
         TorchTestData: Configured test data for DNA experiments with float values.
     """
     data = TorchTestData("tests/test_data/dna_experiment/test_unequal_dna_float.csv", DnaToFloatExperiment)
-    data.expected_len = 4
-    data.expected_input_shape = {"hello": [4, 31, 4]}
-    data.expected_label_shape = {"hola": [4]}
-    data.expected_item_shape = {"hello": [31, 4]}
+    data.hardcoded_expected_len = 4
+    data.hardcoded_expected_input_shape = {"hello": [4, 31, 4]}
+    data.hardcoded_expected_label_shape = {"hola": [4]}
     return data
 
 
 @pytest.fixture
 def prot_dna_test_data():
     """Fixture providing test data for Protein-DNA experiment.
-
     Returns:
         TorchTestData: Configured test data for Protein-DNA experiments.
     """
     data = TorchTestData("tests/test_data/prot_dna_experiment/test.csv", ProtDnaToFloatExperiment)
-    data.expected_len = 2
-    data.expected_input_shape = {"hello": [2, 16, 4], "bonjour": [2, 15, 20]}
-    data.expected_label_shape = {"hola": [2]}
-    data.expected_item_shape = {"hello": [16, 4], "bonjour": [15, 20]}
+    data.hardcoded_expected_len = 2
+    data.hardcoded_expected_input_shape = {"hello": [2, 16, 4], "bonjour": [2, 15, 20]}
+    data.hardcoded_expected_label_shape = {"hola": [2]}
     return data
 
 
@@ -93,13 +167,13 @@ def prot_dna_test_data():
 )
 def test_data_length(request, fixture_name: str):
     """Test if dataset length matches expected length.
-
     Args:
         request: Pytest fixture request.
         fixture_name: Name of the fixture to test.
     """
     data = request.getfixturevalue(fixture_name)
     assert len(data.torch_dataset) == data.expected_len
+    assert len(data.torch_dataset) == data.hardcoded_expected_len
 
 
 @pytest.mark.parametrize(
@@ -111,11 +185,17 @@ def test_data_length(request, fixture_name: str):
     ],
 )
 class TestDictOfTensors:
-    """Test that torch dataset properly parses dictionaries of tensors."""
+    """Test suite for verifying proper parsing of PyTorch datasets into dictionaries of tensors.
 
+    This test class ensures that:
+    1. Input and label data are properly structured as dictionaries
+    2. The dictionaries contain PyTorch tensors
+    3. Tensor shapes match expected dimensions
+    4. Tensor contents match expected values
+    """
+    
     def test_input_is_dict(self, request, fixture_name: str):
         """Test if input is a dictionary.
-
         Args:
             request: Pytest fixture request.
             fixture_name: Name of the fixture to test.
@@ -125,7 +205,6 @@ class TestDictOfTensors:
 
     def test_label_is_dict(self, request, fixture_name: str):
         """Test if label is a dictionary.
-
         Args:
             request: Pytest fixture request.
             fixture_name: Name of the fixture to test.
@@ -133,29 +212,105 @@ class TestDictOfTensors:
         data = request.getfixturevalue(fixture_name)
         assert isinstance(data.torch_dataset.label, Dict)
 
-    def test_input_tensor_shape(self, request, fixture_name: str):
-        """Test if input tensor shapes match expected shapes.
+    def test_input_is_dict_of_tensors(self, request, fixture_name: str):
+        """Test if input values in torch dataset are PyTorch tensors.
+
+        This test verifies that all values in the torch dataset's input dictionary
+        are instances of torch.Tensor.
 
         Args:
-            request: Pytest fixture request.
-            fixture_name: Name of the fixture to test.
+            request: Pytest fixture request object
+            fixture_name (str): Name of the fixture to load test data from
+        """
+        data = request.getfixturevalue(fixture_name)
+        for tensor in data.torch_dataset.input.values():
+            assert isinstance(tensor, torch.Tensor)
+
+    def test_label_is_dict_of_tensors(self, request, fixture_name: str):
+        """Test if dataset labels are PyTorch tensors.
+
+        This test verifies that all values in the label dictionary of a torch dataset
+        are PyTorch tensor objects.
+
+        Args:
+            request: Pytest fixture request object
+            fixture_name (str): Name of the fixture containing test data
+        """
+        data = request.getfixturevalue(fixture_name)
+        for tensor in data.torch_dataset.label.values():
+            assert isinstance(tensor, torch.Tensor)
+
+    def test_input_tensor_shapes(self, request, fixture_name: str):
+        """Test if input tensor shapes match expected shapes.
+
+        This test verifies that the shapes of input tensors in the torch dataset match both:
+        1. The shapes of expected input tensors
+        2. The hardcoded expected input shapes (if provided)
+
+        Args:
+            request: Pytest fixture request object
+            fixture_name (str): Name of the fixture containing test data
+
+        The fixture data should contain:
+            - torch_dataset.input: Dict of input tensors
+            - expected_input: Dict of expected tensor shapes
+            - hardcoded_expected_input_shape: Dict of hardcoded expected shapes (optional)
         """
         data = request.getfixturevalue(fixture_name)
         for key, tensor in data.torch_dataset.input.items():
-            assert isinstance(tensor, torch.Tensor)
-            assert tensor.shape == torch.Size(data.expected_input_shape[key])
+            assert tensor.shape == data.expected_input[key].shape
+            if data.hardcoded_expected_input_shape is not None:
+                assert tensor.shape == torch.Size(data.hardcoded_expected_input_shape[key])
 
-    def test_label_tensor_shape(self, request, fixture_name: str):
+    def test_label_tensor_shapes(self, request, fixture_name: str):
         """Test if label tensor shapes match expected shapes.
 
+        This test verifies that the shapes of label tensors in the torch dataset match both:
+        1. The shapes of expected label tensors
+        2. The hardcoded expected label shapes (if provided)
+
         Args:
-            request: Pytest fixture request.
-            fixture_name: Name of the fixture to test.
+            request: Pytest fixture request object
+            fixture_name (str): Name of the fixture containing test data
+
+        The fixture data should contain:
+            - torch_dataset.label: Dict of label tensors
+            - expected_label: Dict of expected tensor shapes
+            - hardcoded_expected_label_shape: Dict of hardcoded expected shapes (optional)
         """
         data = request.getfixturevalue(fixture_name)
         for key, tensor in data.torch_dataset.label.items():
-            assert isinstance(tensor, torch.Tensor)
-            assert tensor.shape == torch.Size(data.expected_label_shape[key])
+            assert tensor.shape == data.expected_label[key].shape
+            if data.hardcoded_expected_label_shape is not None:
+                assert tensor.shape == torch.Size(data.hardcoded_expected_label_shape[key])
+
+    def test_input_tensor_content(self, request, fixture_name: str):
+        """Tests if input tensors in a PyTorch dataset match their expected values.
+
+        Args:
+            request: Pytest fixture request object for accessing test fixtures
+            fixture_name (str): Name of the fixture containing test data
+
+        The test verifies that for each key-tensor pair in the torch_dataset.input,
+        the tensor exactly matches the corresponding tensor in expected_input.
+        """
+        data = request.getfixturevalue(fixture_name)
+        for key, tensor in data.torch_dataset.input.items():
+            assert torch.equal(tensor, data.expected_input[key])
+
+    def test_label_tensor_content(self, request, fixture_name: str):
+        """Tests if label tensors in a PyTorch dataset match their expected values.
+
+        Args:
+            request: Pytest fixture request object for accessing test fixtures
+            fixture_name (str): Name of the fixture containing test data
+
+        The test verifies that for each key-tensor pair in the torch_dataset.label,
+        the tensor exactly matches the corresponding tensor in expected_label.
+        """
+        data = request.getfixturevalue(fixture_name)
+        for key, tensor in data.torch_dataset.label.items():
+            assert torch.equal(tensor, data.expected_label[key])
 
 
 @pytest.mark.parametrize(
@@ -170,7 +325,11 @@ class TestDictOfTensors:
     ],
 )
 class TestGetItem:
-    """Test suite for dataset item retrieval."""
+    """Test suite for verifying the __getitem__ method of the TorchDataset class.
+
+    This class contains tests to verify the behavior of the __getitem__ method,
+    ensuring that it returns properly structured dictionaries with correctly shaped tensors.
+    """
 
     def test_is_dict(self, request, fixture_name: str, idx: Any):
         """Test if retrieved items are dictionaries.
@@ -197,11 +356,12 @@ class TestGetItem:
         data = request.getfixturevalue(fixture_name)
         x, y, meta = data.torch_dataset[idx]
         dict_items = {**x, **y, **meta}
-        for key, expected_item_shape in data.expected_item_shape.items():
+        for key, expected_shape in data.expected_input_shape.items():
+            expected_shape = list(expected_shape)[1:]  # the first dimension is the batch size
             if isinstance(idx, slice):
                 slice_len = idx.stop - idx.start
-                expected_item_shape = [slice_len] + expected_item_shape
-            assert dict_items[key].shape == torch.Size(expected_item_shape)
+                expected_shape = [slice_len] + expected_shape
+            assert dict_items[key].shape == torch.Size(expected_shape)
 
 
 # TODO add test for titanic dataset

--- a/tests/test_handlertorch.py
+++ b/tests/test_handlertorch.py
@@ -25,10 +25,10 @@ Test Organization:
     TestExpectations
         - Validates test data integrity
         - Verifies expected values match hardcoded values, when provided
-    
+
     TestTorchDataset
         - TestTorchDatasetStructure: Basic dataset properties
-        - TestTorchDatasetContent: Data content validation 
+        - TestTorchDatasetContent: Data content validation
         - TestTorchDatasetGetItem: Indexing operations
 
 Usage:
@@ -92,7 +92,7 @@ class TorchTestData:
         self.hardcoded_expected_values = {
             "length": None,
             "input_shape": None,
-            "label_shape": None
+            "label_shape": None,
         }
 
     def get_encoded_padded_category(self, data: pl.DataFrame, category: str) -> Dict[str, Union[Tensor, pl.Series]]:
@@ -140,23 +140,37 @@ class TorchTestData:
         return columns
 
 
-@pytest.fixture(params=[
-    ("tests/test_data/dna_experiment/test.csv", DnaToFloatExperiment, {
-        "length": 2,
-        "input_shape": {"hello": [2, 16, 4]},
-        "label_shape": {"hola": [2]}
-    }),
-    ("tests/test_data/dna_experiment/test_unequal_dna_float.csv", DnaToFloatExperiment, {
-        "length": 4,
-        "input_shape": {"hello": [4, 31, 4]},
-        "label_shape": {"hola": [4]}
-    }),
-    ("tests/test_data/prot_dna_experiment/test.csv", ProtDnaToFloatExperiment, {
-        "length": 2,
-        "input_shape": {"hello": [2, 16, 4], "bonjour": [2, 15, 20]},
-        "label_shape": {"hola": [2]}
-    })
-])
+@pytest.fixture(
+    params=[
+        (
+            "tests/test_data/dna_experiment/test.csv",
+            DnaToFloatExperiment,
+            {
+                "length": 2,
+                "input_shape": {"hello": [2, 16, 4]},
+                "label_shape": {"hola": [2]},
+            },
+        ),
+        (
+            "tests/test_data/dna_experiment/test_unequal_dna_float.csv",
+            DnaToFloatExperiment,
+            {
+                "length": 4,
+                "input_shape": {"hello": [4, 31, 4]},
+                "label_shape": {"hola": [4]},
+            },
+        ),
+        (
+            "tests/test_data/prot_dna_experiment/test.csv",
+            ProtDnaToFloatExperiment,
+            {
+                "length": 2,
+                "input_shape": {"hello": [2, 16, 4], "bonjour": [2, 15, 20]},
+                "label_shape": {"hola": [2]},
+            },
+        ),
+    ]
+)
 def test_data(request) -> TorchTestData:
     """Parametrized fixture providing test data for all experiment types.
 
@@ -206,16 +220,16 @@ class TestExpectations:
         assert test_data.expected_len is not None, "Expected length is not defined"
         assert test_data.expected_input_shape is not None, "Expected input shape is not defined"
         assert test_data.expected_label_shape is not None, "Expected label shape is not defined"
-    
+
     def test_expected_values_match_hardcoded(self, test_data) -> None:
         """Validate the expected values match the hardcoded values, when provided.
-        
+
         Since we defined the expected values by computing them from the test data with
         alternative ways, we need to ensure they are correct. This function validates
-        the expected values match the hardcoded values in the test data, if provided. 
-        Once verified, the rest of the tests will use the expected values for 
+        the expected values match the hardcoded values in the test data, if provided.
+        Once verified, the rest of the tests will use the expected values for
         validation.
-        
+
         Args:
             test_data (TorchTestData): Test data fixture.
 
@@ -249,7 +263,7 @@ class TestExpectations:
 class TestTorchDataset:
     """Test suite for TorchDataset functionality.
 
-    This class contains tests for verifying the behavior and functionality 
+    This class contains tests for verifying the behavior and functionality
     of the TorchDataset class implementation. It tests dataset length, data structure,
     and indexing operations.
 
@@ -286,12 +300,8 @@ class TestTorchDataset:
                 AssertionError: If either 'input' or 'label' attributes are missing from
                                the torch_dataset.
             """
-            assert hasattr(test_data.torch_dataset, "input"), (
-                "TorchDataset does not have 'input' attribute"
-            )
-            assert hasattr(test_data.torch_dataset, "label"), (
-                "TorchDataset does not have 'label' attribute"
-            )
+            assert hasattr(test_data.torch_dataset, "input"), "TorchDataset does not have 'input' attribute"
+            assert hasattr(test_data.torch_dataset, "label"), "TorchDataset does not have 'label' attribute"
 
         def test_dataset_length(self, test_data) -> None:
             """Test dataset length.
@@ -305,8 +315,7 @@ class TestTorchDataset:
                 AssertionError: If the torch dataset length does not match expected_len.
             """
             assert len(test_data.torch_dataset) == test_data.expected_len, (
-                f"Dataset length mismatch: "
-                f"got {len(test_data.torch_dataset)}, expected {test_data.expected_len}"
+                f"Dataset length mismatch: " f"got {len(test_data.torch_dataset)}, expected {test_data.expected_len}"
             )
 
         @pytest.mark.parametrize("category", ["input", "label"])
@@ -322,18 +331,14 @@ class TestTorchDataset:
                 category (str): Name of the category/attribute to test (e.g., 'input', 'label')
 
             Raises:
-                AssertionError: 
+                AssertionError:
                     - If the category is not a dictionary
                     - If any value in the dictionary is not a PyTorch Tensor
             """
             data_dict = getattr(test_data.torch_dataset, category)
-            assert isinstance(data_dict, dict), (
-                f"{category} is not a dictionary: got {type(data_dict)}"
-            )
+            assert isinstance(data_dict, dict), f"{category} is not a dictionary: got {type(data_dict)}"
             for key, value in data_dict.items():
-                assert isinstance(value, Tensor), (
-                    f"{category}[{key}] is not a Tensor, got {type(value)}"
-                )
+                assert isinstance(value, Tensor), f"{category}[{key}] is not a Tensor, got {type(value)}"
 
     class TestTorchDatasetContent:
         """A test class for verifying the content of PyTorch datasets.
@@ -354,8 +359,7 @@ class TestTorchDataset:
 
         @pytest.mark.parametrize("category", ["input", "label"])
         def test_tensor_keys(self, test_data, category: str) -> None:
-            """
-            Test if the tensor keys in the dataset match expected keys.
+            """Test if the tensor keys in the dataset match expected keys.
 
             Args:
                 test_data: TestData object containing the dataset and expected values
@@ -367,8 +371,7 @@ class TestTorchDataset:
             data_dict = getattr(test_data.torch_dataset, category)
             expected_keys = test_data.expected_input.keys() if category == "input" else test_data.expected_label.keys()
             assert set(data_dict.keys()) == set(expected_keys), (
-                f"Keys mismatch for {category}: "
-                f"got {set(data_dict.keys())}, expected {set(expected_keys)}"
+                f"Keys mismatch for {category}: " f"got {set(data_dict.keys())}, expected {set(expected_keys)}"
             )
 
         @pytest.mark.parametrize("category", ["input", "label"])
@@ -388,12 +391,10 @@ class TestTorchDataset:
             data_dict = getattr(test_data.torch_dataset, category)
             for key, tensor in data_dict.items():
                 expected_shape = (
-                    test_data.expected_input_shape[key] if category == "input"
-                    else test_data.expected_label_shape[key]
+                    test_data.expected_input_shape[key] if category == "input" else test_data.expected_label_shape[key]
                 )
                 assert tensor.shape == expected_shape, (
-                    f"Shape mismatch for {category}[{key}]: "
-                    f"got {tensor.shape}, expected {expected_shape}"
+                    f"Shape mismatch for {category}[{key}]: " f"got {tensor.shape}, expected {expected_shape}"
                 )
 
         @pytest.mark.parametrize("category", ["input", "label"])
@@ -413,12 +414,10 @@ class TestTorchDataset:
             data_dict = getattr(test_data.torch_dataset, category)
             for key, tensor in data_dict.items():
                 expected_tensor = (
-                    test_data.expected_input[key] if category == "input"
-                    else test_data.expected_label[key]
+                    test_data.expected_input[key] if category == "input" else test_data.expected_label[key]
                 )
                 assert torch.equal(tensor, expected_tensor), (
-                    f"Content mismatch for {category}[{key}]: "
-                    f"got {tensor}, expected {expected_tensor}"
+                    f"Content mismatch for {category}[{key}]: " f"got {tensor}, expected {expected_tensor}"
                 )
 
     class TestTorchDatasetGetItem:
@@ -463,12 +462,12 @@ class TestTorchDataset:
                 AssertionError: If any of the returned structures don't match expected types
             """
             x, y, meta = test_data.torch_dataset[idx]
-            
+
             # Test items are dictionaries
             assert isinstance(x, dict), f"Expected input to be dict, got {type(x)}"
             assert isinstance(y, dict), f"Expected label to be dict, got {type(y)}"
             assert isinstance(meta, dict), f"Expected meta to be dict, got {type(meta)}"
-            
+
             # Test item contents are tensors
             for key, value in x.items():
                 assert isinstance(value, Tensor), f"Input tensor {key} is not a Tensor"
@@ -476,14 +475,17 @@ class TestTorchDataset:
                 assert isinstance(value, Tensor), f"Label tensor {key} is not a Tensor"
 
         @pytest.mark.parametrize("idx", [0, slice(0, 2)])
-        @pytest.mark.parametrize("category_info", [
-            ("input", "x", "expected_input"),
-            ("label", "y", "expected_label")
-        ])
+        @pytest.mark.parametrize(
+            "category_info",
+            [
+                ("input", "x", "expected_input"),
+                ("label", "y", "expected_label"),
+            ],
+        )
         def test_get_item_keys_are_correct(self, test_data, idx: Union[int, slice], category_info: tuple) -> None:
             """Test if the keys in retrieved dataset items match expected keys.
 
-            This test verifies that the keys in the retrieved dataset items (either input 'x' or label 'y') 
+            This test verifies that the keys in the retrieved dataset items (either input 'x' or label 'y')
             match the expected keys stored in the dataset attributes.
 
             Args:
@@ -498,30 +500,29 @@ class TestTorchDataset:
                 AssertionError: If the keys in the retrieved item don't match the expected keys
             """
             category, data_attr, expected_attr = category_info
-            
+
             # get dataset item
             x, y, _ = test_data.torch_dataset[idx]
             keys = set(x.keys()) if category == "input" else set(y.keys())
             expected_keys = set(getattr(test_data, expected_attr).keys())
 
             # verify keys
-            assert keys == expected_keys, (
-                f"Keys mismatch for {category}: "
-                f"got {keys}, "
-                f"expected {expected_keys}"
-            )
+            assert keys == expected_keys, f"Keys mismatch for {category}: " f"got {keys}, " f"expected {expected_keys}"
 
         @pytest.mark.parametrize("idx", [0, slice(0, 2)])
-        @pytest.mark.parametrize("category_info", [
-            ("input", "x", "expected_input_shape"),
-            ("label", "y", "expected_label_shape")
-        ])
+        @pytest.mark.parametrize(
+            "category_info",
+            [
+                ("input", "x", "expected_input_shape"),
+                ("label", "y", "expected_label_shape"),
+            ],
+        )
         def test_get_item_shapes(self, test_data, idx: Union[int, slice], category_info: tuple) -> None:
             """Test if dataset items have the correct shapes for both input and target tensors..
 
-            This test verifies that tensor shapes match expected shapes for either input or label 
+            This test verifies that tensor shapes match expected shapes for either input or label
             data. For slice indices, it accounts for the batch dimension in the expected shape.
-            The test compares each tensor's shape against the expected shape stored in the 
+            The test compares each tensor's shape against the expected shape stored in the
             data handler's attributes.
 
             Args:
@@ -541,30 +542,31 @@ class TestTorchDataset:
             x, y, _ = test_data.torch_dataset[idx]
             data = x if category == "input" else y
             expected_shapes = getattr(test_data, expected_attr)
-            
-            # test each tensor has the proper shape
-            for key,tensor in data.items():
 
+            # test each tensor has the proper shape
+            for key, tensor in data.items():
                 # get expected shape
                 expected_shape = expected_shapes[key]
-                base_shape = list(expected_shape)[1:] if len(expected_shape) > 1 else [] # remove batch dimension
+                base_shape = list(expected_shape)[1:] if len(expected_shape) > 1 else []  # remove batch dimension
                 if isinstance(idx, slice):
                     expected_shape = [idx.stop - idx.start] + base_shape
                 else:
                     expected_shape = base_shape
                 expected_shape = torch.Size(expected_shape)
-                    
+
                 # verify shape
                 assert tensor.shape == expected_shape, (
-                    f"Wrong shape for {category}[{key}]: "
-                    f"got {tensor.shape}, expected {expected_shape}"
+                    f"Wrong shape for {category}[{key}]: " f"got {tensor.shape}, expected {expected_shape}"
                 )
 
         @pytest.mark.parametrize("idx", [0, slice(0, 2)])
-        @pytest.mark.parametrize("category_info", [
-            ("input", "x", "expected_input"),
-            ("label", "y", "expected_label")
-        ])
+        @pytest.mark.parametrize(
+            "category_info",
+            [
+                ("input", "x", "expected_input"),
+                ("label", "y", "expected_label"),
+            ],
+        )
         def test_get_item_content(self, test_data, idx: Union[int, slice], category_info: tuple) -> None:
             """Test if the content of items retrieved from torch_dataset is correct.
 
@@ -590,19 +592,18 @@ class TestTorchDataset:
             expected_data = getattr(test_data, expected_attr)
 
             # test each tensor has the proper content
-            for key,tensor in data.items():
+            for key, tensor in data.items():
                 expected_tensor = expected_data[key][idx]
 
                 assert torch.equal(tensor, expected_tensor), (
-                    f"Content mismatch for {category}[{key}]: "
-                    f"got {tensor}, expected {expected_tensor}"
+                    f"Content mismatch for {category}[{key}]: " f"got {tensor}, expected {expected_tensor}"
                 )
 
         @pytest.mark.parametrize("invalid_idx", [5000])
-        def test_getitem_invalid_index(self, test_data, invalid_idx: Union[int,slice]) -> None:
+        def test_getitem_invalid_index(self, test_data, invalid_idx: Union[int, slice]) -> None:
             """Test whether invalid indexing raises appropriate exceptions.
 
-            Tests if accessing test_data.torch_dataset with an invalid index raises 
+            Tests if accessing test_data.torch_dataset with an invalid index raises
             an IndexError exception.
 
             Args:
@@ -614,5 +615,6 @@ class TestTorchDataset:
             """
             with pytest.raises(IndexError):
                 _ = test_data.torch_dataset[invalid_idx]
-        
+
+
 # TODO add tests for titanic dataset

--- a/tests/test_handlertorch.py
+++ b/tests/test_handlertorch.py
@@ -1,0 +1,123 @@
+import os
+import pytest
+import torch
+from typing import Any, Dict
+
+from src.stimulus.data.experiments import DnaToFloatExperiment, ProtDnaToFloatExperiment, TitanicExperiment
+from src.stimulus.data.handlertorch import TorchDataset
+
+
+class TorchTestData:
+    def __init__(self, filename: str, experiment: Any):
+        self.experiment = experiment()
+        self.csv_path = os.path.abspath(filename)
+        self.torch_dataset = TorchDataset(self.csv_path, self.experiment)
+        print(self.torch_dataset.input)
+        self.expected_len = None
+        self.expected_input_shape = None
+        self.expected_label_shape = None
+        self.expected_item_shape = None
+
+
+@pytest.fixture
+def dna_test_data():
+    data = TorchTestData("tests/test_data/dna_experiment/test.csv", DnaToFloatExperiment)
+    data.expected_len = 2
+    data.expected_input_shape = {"hello": [2, 16, 4]}
+    data.expected_label_shape = {"hola": [2]}
+    data.expected_item_shape = {"hello": [16, 4]}
+    return data
+
+
+@pytest.fixture
+def dna_test_data_with_float():
+    data = TorchTestData("tests/test_data/dna_experiment/test_unequal_dna_float.csv", DnaToFloatExperiment)
+    data.expected_len = 4
+    data.expected_input_shape = {"hello": [4, 31, 4]}
+    data.expected_label_shape = {"hola": [4]}
+    data.expected_item_shape = {"hello": [31, 4]}
+    return data
+
+
+@pytest.fixture
+def prot_dna_test_data():
+    data = TorchTestData("tests/test_data/prot_dna_experiment/test.csv", ProtDnaToFloatExperiment)
+    data.expected_len = 2
+    data.expected_input_shape = {"hello": [2, 16, 4], "bonjour": [2, 15, 20]}
+    data.expected_label_shape = {"hola": [2]}
+    data.expected_item_shape = {"hello": [16, 4], "bonjour": [15, 20]}
+    return data
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        ("dna_test_data"),
+        ("dna_test_data_with_float"),
+        ("prot_dna_test_data"),
+    ],
+)
+def test_data_length(request, fixture_name: str):
+    data = request.getfixturevalue(fixture_name)
+    assert len(data.torch_dataset) == data.expected_len
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        ("dna_test_data"),
+        ("dna_test_data_with_float"),
+        ("prot_dna_test_data"),
+    ],
+)
+class TestDictOfTensors:
+
+    def test_input_is_dict(self, request, fixture_name: str):
+        data = request.getfixturevalue(fixture_name)
+        assert isinstance(data.torch_dataset.input, Dict)
+
+    def test_label_is_dict(self, request, fixture_name: str):
+        data = request.getfixturevalue(fixture_name)
+        assert isinstance(data.torch_dataset.label, Dict)
+
+    def test_input_tensor_shape(self, request, fixture_name: str):
+        data = request.getfixturevalue(fixture_name)
+        for key, tensor in data.torch_dataset.input.items():
+            assert isinstance(tensor, torch.Tensor)
+            assert tensor.shape == torch.Size(data.expected_input_shape[key])
+    
+    def test_label_tensor_shape(self, request, fixture_name: str):
+        data = request.getfixturevalue(fixture_name)
+        for key, tensor in data.torch_dataset.label.items():
+            assert isinstance(tensor, torch.Tensor)
+            assert tensor.shape == torch.Size(data.expected_label_shape[key])
+
+
+@pytest.mark.parametrize(
+    "fixture_name,idx",
+    [
+        ("dna_test_data", 0),
+        ("dna_test_data_with_float", 0),
+        ("prot_dna_test_data", 0),
+    ],
+)
+class TestGetItem:
+
+    def test_is_dict(self, request, fixture_name: str, idx: Any):
+        data = request.getfixturevalue(fixture_name)
+        x, y, meta = data.torch_dataset[idx]
+        assert isinstance(x, dict)
+        assert isinstance(y, dict)
+        assert isinstance(meta, dict)
+
+    def test_get_correct_items(self, request, fixture_name: str, idx: Any):
+        data = request.getfixturevalue(fixture_name)
+        x, y, meta = data.torch_dataset[idx]
+        dict_items = {**x, **y, **meta}
+        for key, expected_item_shape in data.expected_item_shape.items():
+            if isinstance(idx, slice):
+                slice_len = idx.stop - idx.start
+                expected_item_shape = [slice_len] + expected_item_shape
+            assert dict_items[key].shape == torch.Size(expected_item_shape)
+
+# TODO add test for titanic dataset


### PR DESCRIPTION
- [x] a pytest test for handletorch is added as an adaption from the previous unittest version (now deprecated).
- [x] make format to improve formatting etc
- [x] modified ruff.toml configurations to not run linting on unittest fiiles 