### PR TITLE
Refractoring of base registry to be class insensitive

### DIFF
--- a/src/stimulus/core/registry.py
+++ b/src/stimulus/core/registry.py
@@ -1,168 +1,53 @@
-"""Central registry system for Stimulus components.
-
-The registry system provides a way to register and manage different implementations
-of components like encoders, decoders, processors etc. Components can be registered
-either through decorators or through entry points for plugin support.
-
-Example:
-    Here's how to create and use a registry for encoders:
-
-    ```python
-    from abc import ABC, abstractmethod
-    from stimulus.core.registry import BaseRegistry
+from typing import Type, Callable
 
 
-    # Define your component interface
-    class BaseEncoder(ABC):
-        @abstractmethod
-        def encode(self, data: str) -> bytes:
-            pass
-
-        @abstractmethod
-        def decode(self, data: bytes) -> str:
-            pass
-
-
-    # Create a registry
-    encoder_registry = BaseRegistry("stimulus.encoders", BaseEncoder)
-
-
-    # Register a component
-    @encoder_registry.register("base64")
-    class Base64Encoder(BaseEncoder):
-        def encode(self, data: str) -> bytes:
-            import base64
-
-            return base64.b64encode(data.encode())
-
-        def decode(self, data: bytes) -> str:
-            import base64
-
-            return base64.b64decode(data).decode()
-
-
-    # Use the registered component
-    encoder = encoder_registry.get("base64")
-    encoded = encoder.encode("Hello World")regi
-    decoded = encoder.decode(encoded)
-    ```
-
-For plugin support, external packages can register components via entry points
-in their setup.py/pyproject.toml:
-
-```toml
-[project.entry-points."stimulus.encoders"]
-my_encoder = "mypackage.encoders:CustomEncoder"
-```
-"""
-
-from importlib.metadata import entry_points
-from typing import Any, Callable, Generic, TypeVar
-
-T = TypeVar("T")
-
-
-class BaseRegistry(Generic[T]):
-    """Base registry class for component registration.
-
-    This class provides a foundation for registering and managing components in Stimulus.
-    Components must inherit from a specified base class and can be registered either
-    through decorators or entry points.
-
-    Args:
-        entry_point_group (str): The entry point group name for plugin discovery
-        base_class (type[T]): The base class that all components must inherit from
-
-    Example:
-        ```python
-        class MyComponent(ABC):
-            pass
-
-
-        registry = BaseRegistry[MyComponent]("stimulus.components", MyComponent)
-
-
-        @registry.register("my_component")
-        class CustomComponent(MyComponent):
-            pass
-        ```
+class BaseRegistry(type):
+    """
+    A generic registry implementation.
+    source: https://charlesreid1.github.io/python-patterns-the-registry.html#registry-subclasses
     """
 
-    def __init__(self, entry_point_group: str, base_class: type[T]):
-        """Initialize BaseRegistry class."""
-        self._components: dict[str, type[T]] = {}
-        self.entry_point_group = entry_point_group
-        self.base_class = base_class
-        self.load_builtins()
-        self.load_plugins()
+    _REGISTRY: dict[str, Type[object]] = {}
 
-    def register(self, name: str) -> Callable:
-        """Decorator factory for component registration.
+    def __new__(cls, name: str, bases: tuple, attrs: dict[str, str]) -> None:
+        """
+        Using __new__ instead of __init__ to register at definition and not class declaration.
+
+        When a class inherits from this class as metaclass it is saved in the registry and all children will also be saved
 
         Args:
-            name (str): The name to register the component under
-
-        Returns:
-            Callable: A decorator that registers the component
-
-        Raises:
-            TypeError: If the decorated class doesn't inherit from the base class
+            class_to_register (Any): The python class to register.
+            name (:obj:`str`, optional): A name for the registered class.
+                If None, the class name will be used
         """
+        new_cls: Type[object] = type.__new__(cls, name, bases, attrs)
+        cls.save_class(new_cls, name)
+        return new_cls
 
-        def decorator(component_class: type[T]) -> type[T]:
-            if not issubclass(component_class, self.base_class):
-                raise TypeError(
-                    f"{component_class.__name__} must subclass {self.base_class.__name__}",
-                )
-            self._components[name] = component_class
-            return component_class
+    @classmethod
+    def save_class(
+        cls, class_to_register: Type[object], name: str | None = None
+    ) -> None:
+        """Saves the class and the given name in the registry."""
+        if name is None:
+            name = class_to_register.__name__
+        cls._REGISTRY[name.lower()] = class_to_register
 
-        return decorator
+    @classmethod
+    def register(cls, name: str | None = None) -> Type[object]:
+        def wrapper(wrapped_class: Type[object]) -> Type[object]:
+            """Wrapper function to save a class to the registry."""
+            cls.save_class(wrapped_class, name)
+            return wrapped_class
 
-    def load_builtins(self) -> None:
-        """Override in child classes to register built-in components."""
+        return wrapper
 
-    def load_plugins(self) -> None:
-        """Load external components from entry points."""
-        try:
-            eps = entry_points()
-            if hasattr(eps, "select"):  # Python 3.10+ API
-                plugins = eps.select(group=self.entry_point_group)
+    @classmethod
+    def get(cls, name: str) -> Type[object]:
+        """Returns the saved classe with a given name as key."""
+        return cls._REGISTRY.get(name.lower())
 
-            for ep in plugins:
-                self._components[ep.name] = ep.load()
-        except ValueError as e:
-            # Log warning but don't fail if plugin loading fails
-            import warnings
-
-            warnings.warn(f"Failed to load plugins: {e!s}", stacklevel=2)
-
-    def get(self, name: str, **params: dict[str, Any]) -> T:
-        """Instantiate a component with parameters.
-
-        Args:
-            name (str): The registered name of the component
-            **params: Parameters to pass to the component constructor
-
-        Returns:
-            T: An instance of the requested component
-
-        Raises:
-            ValueError: If the component name is not registered
-        """
-        component_class = self._components.get(name)
-        if not component_class:
-            available = ", ".join(sorted(self._components.keys()))
-            raise ValueError(
-                f"Unknown {self.base_class.__name__} '{name}'. Available: {available}",
-            )
-        return component_class(**params)
-
-    @property
-    def component_names(self) -> list[str]:
-        """Get a list of all registered component names.
-
-        Returns:
-            list[str]: Sorted list of component names
-        """
-        return sorted(self._components.keys())
+    @classmethod
+    def all(cls) -> dict[str, Type[object]]:
+        """Return all the saved classes."""
+        return cls._REGISTRY

--- a/src/stimulus/core/registry.py
+++ b/src/stimulus/core/registry.py
@@ -1,32 +1,46 @@
-from typing import Type, Callable
+"""A common basic registry object for all type of classes.
+
+This registry can add a class to the registry either by using
+metaclass=BaseRegistry in a new object or using the wrapper
+function as a header `@BaseRegistry.register(name)`
+"""
+
+from typing import Callable, ClassVar
 
 
 class BaseRegistry(type):
+    """A generic registry implementation.
+
+    #registry-subclasses.
+    Source: https://charlesreid1.github.io/python-patterns-the-registry.html
     """
-    A generic registry implementation.
-    source: https://charlesreid1.github.io/python-patterns-the-registry.html#registry-subclasses
-    """
 
-    _REGISTRY: dict[str, Type[object]] = {}
+    _REGISTRY: ClassVar[dict[str, type[object]]] = {}
 
-    def __new__(cls, name: str, bases: tuple, attrs: dict[str, str]) -> None:
-        """
-        Using __new__ instead of __init__ to register at definition and not class declaration.
+    def __new__(cls, name: str, bases: tuple, attrs: dict[str, str]) -> type[object]:
+        """Using __new__ instead of __init__ to register at definition and not class declaration.
 
-        When a class inherits from this class as metaclass it is saved in the registry and all children will also be saved
+        When a class inherits from this class as metaclass it is saved in the
+        registry and all children will also be saved.
 
         Args:
-            class_to_register (Any): The python class to register.
             name (:obj:`str`, optional): A name for the registered class.
-                If None, the class name will be used
+                If None, the class name will be used.
+            bases (tuple): ???.
+            attrs dict[str, str]: object attributes dictionnary.
+
+        Return:
+            type[object]: returns the given class as input.
         """
-        new_cls: Type[object] = type.__new__(cls, name, bases, attrs)
+        new_cls: type[object] = type.__new__(cls, name, bases, attrs)
         cls.save_class(new_cls, name)
         return new_cls
 
     @classmethod
     def save_class(
-        cls, class_to_register: Type[object], name: str | None = None
+        cls,
+        class_to_register: type[object],
+        name: str | None = None,
     ) -> None:
         """Saves the class and the given name in the registry."""
         if name is None:
@@ -34,8 +48,13 @@ class BaseRegistry(type):
         cls._REGISTRY[name.lower()] = class_to_register
 
     @classmethod
-    def register(cls, name: str | None = None) -> Type[object]:
-        def wrapper(wrapped_class: Type[object]) -> Type[object]:
+    def register(
+        cls,
+        name: str | None = None,
+    ) -> Callable[[type[object]], type[object]]:
+        """Function using a wrapper to register the given class with a specific name."""
+
+        def wrapper(wrapped_class: type[object]) -> type[object]:
             """Wrapper function to save a class to the registry."""
             cls.save_class(wrapped_class, name)
             return wrapped_class
@@ -43,11 +62,11 @@ class BaseRegistry(type):
         return wrapper
 
     @classmethod
-    def get(cls, name: str) -> Type[object]:
+    def get(cls, name: str) -> type[object] | None:
         """Returns the saved classe with a given name as key."""
         return cls._REGISTRY.get(name.lower())
 
     @classmethod
-    def all(cls) -> dict[str, Type[object]]:
+    def all(cls) -> dict[str, type[object]]:
         """Return all the saved classes."""
         return cls._REGISTRY

--- a/tests/core/mock.py
+++ b/tests/core/mock.py
@@ -1,7 +1,12 @@
+"""A mock class to show the registering on import in tests/core/test_registry.py."""
+
 from src.stimulus.core.registry import BaseRegistry
 
 
 @BaseRegistry.register("tEst_ClAss3")
-class class3:
+class Class3:
+    """A mock class."""
+
     def echo(self) -> str:
+        """Returns just class3."""
         return "class3"

--- a/tests/core/mock.py
+++ b/tests/core/mock.py
@@ -1,0 +1,7 @@
+from src.stimulus.core.registry import BaseRegistry
+
+
+@BaseRegistry.register("tEst_ClAss3")
+class class3:
+    def echo(self) -> str:
+        return "class3"

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -1,58 +1,66 @@
-# """Tests for the BaseRegistry class."""
-from src.stimulus.core.registry import BaseRegistry
-from tests.core import mock
+"""Tests for the BaseRegistry class."""
 
-from typing import Type
+from src.stimulus.core.registry import BaseRegistry
+from tests.core import mock  # noqa: F401
 
 
 # Defining a meta class that will automatically be registered
 # as it inherits BaseRegistry as a metaclass.
-class base_test_class(metaclass=BaseRegistry):
+class BaseTestClass(metaclass=BaseRegistry):
+    """Base test class that is registered due to the metaclass."""
+
     def __init__(self) -> None:
+        """Initializes a base and a name attribute."""
         self.base: str = "class"
         self.name: str = "base"
 
-    def echo(self):
+    def echo(self) -> str:
+        """Returns the base + _ + name attributes."""
         return self.base + "_" + self.name
 
 
 # Defining a class that inherits from base_test_class.
 # It will also be added to the registry automatically due
 # to its inheritance
-class class1(base_test_class):
+class Class1(BaseTestClass):
+    """Child class of base_test_class, registered through it's inheritance."""
+
     def __init__(self) -> None:
+        """Init the parent class to get its attributes and the child class."""
         super().__init__()
         self.name = "1"
 
 
 # Register manually a class with the header
 @BaseRegistry.register("test_CLASS2")
-class class2:
+class Class2:
+    """A class that is manually registered in the registry with the header."""
+
     def __init__(self) -> None:
+        """Defines only a name attribute."""
         self.name: str = "class_2"
 
     def echo(self) -> str:
+        """Returns the name attribute."""
         return self.name
 
 
 def test_num_class_in_registry() -> None:
-    """
-    Checks that class1, class2 and mock.class3 are all correctly saved.
-    """
-    registry_classes: dict[str, Type[object]] = BaseRegistry.all()
+    """Checks that class1, class2 and mock.class3 are all correctly saved."""
+    registry_classes: dict[str, type[object]] = BaseRegistry.all()
     assert len(registry_classes) == 4  # 3 in this file + mock
 
 
 def test_name_is_lower_in_registry() -> None:
     """Checks that all the names are saved to lowercase."""
-    registry_classes: dict[str, Type[object]] = BaseRegistry.all()
-    for name, associated_class in registry_classes.items():
+    registry_classes: dict[str, type[object]] = BaseRegistry.all()
+    for name, _associated_class in registry_classes.items():
         assert name.lower() == name
 
 
 def test_class_init_in_registry() -> None:
     """Checks that all the class can be inited and print."""
-    registry_classes: dict[str, Type[object]] = BaseRegistry.all()
-    for name, associated_class in registry_classes.items():
-        name_class: Type[object] = associated_class()
-        assert "class" in name_class.echo()
+    registry_classes: dict[str, type[object]] = BaseRegistry.all()
+    for _name, associated_class in registry_classes.items():
+        name_class: object = associated_class()
+        assert "class" in name_class.echo()  # type: ignore[attr-defined]

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -1,182 +1,58 @@
-"""Tests for the BaseRegistry class."""
+# """Tests for the BaseRegistry class."""
+from src.stimulus.core.registry import BaseRegistry
+from tests.core import mock
 
-import re
-from abc import ABC, abstractmethod
-
-import pytest
-
-from stimulus.core.registry import BaseRegistry
+from typing import Type
 
 
-# Test fixtures
-class MockComponent(ABC):
-    """Mock abstract base class for testing."""
+# Defining a meta class that will automatically be registered
+# as it inherits BaseRegistry as a metaclass.
+class base_test_class(metaclass=BaseRegistry):
+    def __init__(self) -> None:
+        self.base: str = "class"
+        self.name: str = "base"
 
-    @abstractmethod
-    def do_something(self) -> str:
-        """Empty placeholder function."""
-        return "something"
-
-
-class ValidComponent(MockComponent):
-    """Valid component implementation."""
-
-    def __init__(self, param: None = None):
-        """Initialize a valid component with params."""
-        self.param = param
-
-    def do_something(self) -> str:
-        """Simulate the call of a component function."""
-        return "done"
+    def echo(self):
+        return self.base + "_" + self.name
 
 
-class InvalidComponent:
-    """Component that doesn't inherit from base class."""
+# Defining a class that inherits from base_test_class.
+# It will also be added to the registry automatically due
+# to its inheritance
+class class1(base_test_class):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "1"
 
 
-def test_registry_initialization() -> None:
-    """Test basic registry initialization."""
-    registry = BaseRegistry("test.group", MockComponent)
-    assert registry.entry_point_group == "test.group"
-    assert registry.base_class == MockComponent
-    assert len(registry.component_names) == 0
+# Register manually a class with the header
+@BaseRegistry.register("test_CLASS2")
+class class2:
+    def __init__(self) -> None:
+        self.name: str = "class_2"
+
+    def echo(self) -> str:
+        return self.name
 
 
-def test_component_registration() -> None:
-    """Test component registration via decorator."""
-    registry = BaseRegistry("test.group", MockComponent)
-
-    @registry.register("valid")
-    class TestComponent(MockComponent):
-        def do_something(self) -> str:
-            return "test"
-
-    assert "valid" in registry.component_names
-    instance = registry.get("valid")
-    assert isinstance(instance, MockComponent)
-    assert instance.do_something() == "test"
-
-
-def test_invalid_component_registration() -> None:
-    """Test registration of invalid component."""
-    registry = BaseRegistry("test.group", MockComponent)
-
-    with pytest.raises(TypeError, match=re.escape("must subclass")):
-
-        @registry.register("invalid")
-        class TestInvalid(InvalidComponent):
-            pass
-
-
-def test_component_instantiation_with_params() -> None:
-    """Test component instantiation with parameters."""
-    registry = BaseRegistry("test.group", MockComponent)
-
-    @registry.register("parameterized")
-    class TestComponent(ValidComponent):
-        pass
-
-    instance = registry.get("parameterized", param="test_value")
-    assert instance.param == "test_value"
-
-
-def test_unknown_component() -> None:
-    """Test error handling for unknown components."""
-    registry = BaseRegistry("test.group", MockComponent)
-
-    with pytest.raises(
-        # Matches: Unknown [any_char] Available
-        ValueError,
-        match=f"{re.escape('Unknown')}.*{re.escape('Available')}",
-    ) as exc:
-        registry.get("nonexistent")
-
-    assert "Unknown MockComponent 'nonexistent'" in str(exc.value)
-    assert "Available:" in str(exc.value)
-
-
-def test_component_names_sorted() -> None:
-    """Test that component_names returns sorted list."""
-    registry = BaseRegistry("test.group", MockComponent)
-
-    @registry.register("zebra")
-    class ZebraComponent(ValidComponent):
-        pass
-
-    @registry.register("alpha")
-    class AlphaComponent(ValidComponent):
-        pass
-
-    assert registry.component_names == ["alpha", "zebra"]
-
-
-def test_practical_encoder_registry_example() -> None:
-    """Demonstrates practical usage of the registry system for encoders.
-
-    This test shows how to:
-    1. Create a base encoder class
-    2. Create a registry for encoders
-    3. Register custom encoders
-    4. Use the registered encoders
+def test_num_class_in_registry() -> None:
     """
+    Checks that class1, class2 and mock.class3 are all correctly saved.
+    """
+    registry_classes: dict[str, Type[object]] = BaseRegistry.all()
+    assert len(registry_classes) == 4  # 3 in this file + mock
 
-    # 1. Define a base encoder interface
-    class BaseEncoder(ABC):
-        @abstractmethod
-        def encode(self, data: str) -> bytes:
-            """Encode string data into bytes."""
 
-        @abstractmethod
-        def decode(self, data: bytes) -> str:
-            """Decode bytes back into string."""
+def test_name_is_lower_in_registry() -> None:
+    """Checks that all the names are saved to lowercase."""
+    registry_classes: dict[str, Type[object]] = BaseRegistry.all()
+    for name, associated_class in registry_classes.items():
+        assert name.lower() == name
 
-    # 2. Create an encoder registry
-    encoder_registry = BaseRegistry("stimulus.encoders", BaseEncoder)
 
-    # 3. Register a custom encoder
-    @encoder_registry.register("base64")
-    class Base64Encoder(BaseEncoder):
-        def encode(self, data: str) -> bytes:
-            import base64
-
-            return base64.b64encode(data.encode())
-
-        def decode(self, data: bytes) -> str:
-            import base64
-
-            return base64.b64decode(data).decode()
-
-    # 4. Register another encoder
-    @encoder_registry.register("rot13")
-    class Rot13Encoder(BaseEncoder):
-        def encode(self, data: str) -> bytes:
-            return data.encode("rot13")
-
-        def decode(self, data: bytes) -> str:
-            return data.decode().encode("rot13").decode()
-
-    # Test that encoders are registered
-    assert set(encoder_registry.component_names) == {"base64", "rot13"}
-
-    # Test using a registered encoder
-    base64_encoder = encoder_registry.get("base64")
-    test_data = "Hello, World!"
-    encoded = base64_encoder.encode(test_data)
-    decoded = base64_encoder.decode(encoded)
-    assert decoded == test_data
-
-    # Test getting an encoder with parameters
-    @encoder_registry.register("configurable")
-    class ConfigurableEncoder(BaseEncoder):
-        def __init__(self, encoding: str = "utf-8"):
-            self.encoding = encoding
-
-        def encode(self, data: str) -> bytes:
-            return data.encode(self.encoding)
-
-        def decode(self, data: bytes) -> str:
-            return data.decode(self.encoding)
-
-    # Get encoder with custom parameter
-    utf16_encoder = encoder_registry.get("configurable", encoding="utf-16")
-    assert utf16_encoder.encoding == "utf-16"
+def test_class_init_in_registry() -> None:
+    """Checks that all the class can be inited and print."""
+    registry_classes: dict[str, Type[object]] = BaseRegistry.all()
+    for name, associated_class in registry_classes.items():
+        name_class: Type[object] = associated_class()
+        assert "class" in name_class.echo()


### PR DESCRIPTION
# core/registry.py
2 ways of saving a class in the registry:
- either the class or the parent class of the class uses BaseRegistry as a metaclass (all their children will be automatically registered)
- either by using the register wrapper function as an header.
As long as the classes are imported somewhere they will be registered, only non imported classes will not be registered.

(check the test file `tests/core/test_registry.py` to understand how it works)

✓ (python3.10)  Running tests
✓ (python3.11)  Running tests
✓ (python3.11)  Running tests
