### PR TITLE
Minor bug fixes in column encoders

### DIFF
--- a/src/stimulus/data/encoding/encoders.py
+++ b/src/stimulus/data/encoding/encoders.py
@@ -313,7 +313,7 @@ class TextAsciiEncoder(AbstractEncoder):
         decode: decodes a single data point
     """
 
-    def __init__(self, vocab_size: int = 256, dtype: torch.dtype = torch.int8, *, padding: bool = False) -> None:
+    def __init__(self, vocab_size: int = 256, dtype: str = "int8", *, padding: bool = False) -> None:
         """Initialize the TextAsciiEncoder class.
 
         Args:
@@ -322,7 +322,7 @@ class TextAsciiEncoder(AbstractEncoder):
             padding (bool): whether to pad the sequences with zeros. Default = False
         """
         self.vocab_size = vocab_size
-        self.dtype = dtype
+        self.dtype = getattr(torch, dtype)
         self.padding = padding
 
     def encode(self, data: str, length: Optional[int] = None) -> torch.Tensor:

--- a/src/stimulus/data/interface/data_config_schema.py
+++ b/src/stimulus/data/interface/data_config_schema.py
@@ -15,7 +15,7 @@ class ColumnsEncoder(BaseModel):
     """Model for column encoder configuration."""
 
     name: str
-    params: Optional[dict[str, Union[str, list[Any]]]]  # Allow both string and list values
+    params: Optional[dict[str, Union[int, str, list[Any]]]]  # Allow both string and list values
 
 
 class Columns(BaseModel):

--- a/tests/data/encoding/test_encoders.py
+++ b/tests/data/encoding/test_encoders.py
@@ -246,6 +246,13 @@ class TestTextAsciiEncoder:
         assert torch.all(output[0] == torch.tensor([104, 101, 108, 108, 111, 0]))
         assert torch.all(output[1] == torch.tensor([119, 111, 114, 108, 100, 115]))
 
+    def test_encode_dtype(self) -> None:
+        """Test encoding with a non-default dtype."""
+        encoder = TextAsciiEncoder(dtype="int32")
+        input_str = "hello"
+        output = encoder.encode(input_str)
+        assert output.dtype == torch.int32
+
     def test_encode_not_string_raises(self) -> None:
         """Test that encoding a non-string raises a TypeError."""
         encoder = TextAsciiEncoder()


### PR DESCRIPTION
- Fixed dtype handling in ASCII encoder so that it can be passed through the config
- Fixed column encoder schema to allow int parameters