### PR TITLE
Balance sampler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "multiprocess==0.70.17",
     "numpy>=1.26.0,<2.0.0",
     "pandas>=2.2.0",
-    "polars-lts-cpu>=0.20.30,<1.12.0",
+    "polars>=1.25.0,<=1.25.2",
     "pydantic>=2.7.0",
     "safetensors>=0.4.5",
     "scikit-learn>=1.5.0",

--- a/src/stimulus/data/data_handlers.py
+++ b/src/stimulus/data/data_handlers.py
@@ -161,6 +161,11 @@ class DatasetProcessor(DatasetHandler):
                         pl.Series(column_name, transformed_data),
                     )
                     self.data = pl.concat([self.data, new_rows], how="vertical")
+
+                elif transform.remove_row:
+                    self.data = self.data.with_columns(
+                        pl.Series(column_name, transformed_data, strict=False),
+                    ).drop_nans()
                 else:
                     self.data = self.data.with_columns(
                         pl.Series(column_name, transformed_data),

--- a/tests/data/transform/test_data_transformers.py
+++ b/tests/data/transform/test_data_transformers.py
@@ -7,6 +7,7 @@ import pytest
 
 from src.stimulus.data.transforming.transforms import (
     AbstractTransform,
+    BalanceSampler,
     GaussianChunk,
     GaussianNoise,
     ReverseComplement,
@@ -251,3 +252,16 @@ class TestReverseComplement:
         for item in transformed_data:
             assert isinstance(item, str)
         assert transformed_data == test_data.expected_multiple_outputs
+
+
+def test_balance_sampler() -> None:
+    """Test the BalanceSampler class."""
+    sampler = BalanceSampler()
+    data = ["a", "a", "a", "b", "b", "c", "c", "c", "c", "c"]
+    transformed_data = sampler.transform_all(data)
+    nb_a = len([x for x in transformed_data if x == "a"])
+    nb_b = len([x for x in transformed_data if x == "b"])
+    nb_c = len([x for x in transformed_data if x == "c"])
+    nb_nan = len([x for x in transformed_data if x is np.nan])
+    assert nb_a == nb_b == nb_c == 2
+    assert nb_nan == 4


### PR DESCRIPTION
Added a balance sampler for classification tasks, and support in data_handlers to deal with samplers, under two assumptions. 

- Samplers have their class attribute remove_row set to True.
- Samplers replace values that need to be dropped by np.nan.

Additionally, 
Polars version is bumped to take advantage of the drop_nans() feature.