### PR TITLE
Splitter registry

### DIFF
--- a/src/stimulus/core/registry.py
+++ b/src/stimulus/core/registry.py
@@ -5,8 +5,8 @@ metaclass=BaseRegistry in a new object or using the wrapper
 function as a header `@BaseRegistry.register(name)`
 """
 
-from abc import ABC, abstractmethod
 from typing import Callable, ClassVar
+from abc import ABC, abstractmethod
 
 
 class AbstractRegistry(ABC):
@@ -19,71 +19,6 @@ class AbstractRegistry(ABC):
         get: returns the class by given name.
         all: returns all registered classes.
     """
-
-    @abstractmethod
-    def __new__(cls, name: str, bases: tuple, attrs: dict[str, str]) -> type[object]:
-        """Using __new__ instead of __init__ to register at definition and not class declaration.
-
-        When a class inherits from this class as metaclass it is saved in the
-        registry and all children will also be saved.
-
-        Args:
-            name(: obj: `str`, optional): A name for the registered class .
-                If None, the class name will be used.
-            bases(tuple): ???.
-            attrs dict[str, str]: object attributes dictionnary.
-
-        Return:
-            type[object]: returns the given class as input.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def register(
-        cls,
-        name: str | None = None,
-    ) -> Callable[[type[object]], type[object]]:
-        """Function using a wrapper to register the given class with a specific name."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get(cls, name: str) -> type[object] | None:
-        """Returns the saved classe with a given name as key."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def all(cls) -> dict[str, type[object]]:
-        """Return all the saved classes."""
-        raise NotImplementedError
-
-
-class BaseRegistry(type, AbstractRegistry):
-    """A generic registry implementation.
-
-    # registry-subclasses.
-    Source: https: // charlesreid1.github.io/python-patterns-the-registry.html
-    """
-
-    _REGISTRY: ClassVar[dict[str, type[object]]] = {}
-
-    def __new__(cls, name: str, bases: tuple, attrs: dict[str, str]) -> type[object]:
-        """Using __new__ instead of __init__ to register at definition and not class declaration.
-
-        When a class inherits from this class as metaclass it is saved in the
-        registry and all children will also be saved.
-
-        Args:
-            name(: obj: `str`, optional): A name for the registered class .
-                If None, the class name will be used.
-            bases(tuple): ???.
-            attrs dict[str, str]: object attributes dictionnary.
-
-        Return:
-            type[object]: returns the given class as input.
-        """
-        new_cls: type[object] = type.__new__(cls, name, bases, attrs)
-        cls.save_class(new_cls, name)
-        return new_cls
 
     @classmethod
     def save_class(
@@ -119,3 +54,34 @@ class BaseRegistry(type, AbstractRegistry):
     def all(cls) -> dict[str, type[object]]:
         """Return all the saved classes."""
         return cls._REGISTRY
+
+
+class BaseRegistry(AbstractRegistry, type):
+    """A generic registry implementation.
+
+    type is necessary to be registered as a metaclass.
+
+    # registry-subclasses.
+    Source: https: // charlesreid1.github.io/python-patterns-the-registry.html
+    """
+
+    _REGISTRY: ClassVar[dict[str, type[object]]] = {}
+
+    def __new__(cls, name: str, bases: tuple, attrs: dict[str, str]) -> type[object]:
+        """Using __new__ instead of __init__ to register at definition and not class declaration.
+
+        When a class inherits from this class as metaclass it is saved in the
+        registry and all children will also be saved.
+
+        Args:
+            name(: obj: `str`, optional): A name for the registered class .
+                If None, the class name will be used.
+            bases(tuple): ???.
+            attrs dict[str, str]: object attributes dictionnary.
+
+        Return:
+            type[object]: returns the given class as input.
+        """
+        new_cls: type[object] = type.__new__(cls, name, bases, attrs)
+        cls.save_class(new_cls, name)
+        return new_cls

--- a/src/stimulus/core/registry.py
+++ b/src/stimulus/core/registry.py
@@ -5,14 +5,63 @@ metaclass=BaseRegistry in a new object or using the wrapper
 function as a header `@BaseRegistry.register(name)`
 """
 
+from abc import ABC, abstractmethod
 from typing import Callable, ClassVar
 
 
-class BaseRegistry(type):
+class AbstractRegistry(ABC):
+    """Abstract class for registry.
+
+    A registry registers and manage classes.
+
+    Methods:
+        register: wrapper to register a class.
+        get: returns the class by given name.
+        all: returns all registered classes.
+    """
+
+    @abstractmethod
+    def __new__(cls, name: str, bases: tuple, attrs: dict[str, str]) -> type[object]:
+        """Using __new__ instead of __init__ to register at definition and not class declaration.
+
+        When a class inherits from this class as metaclass it is saved in the
+        registry and all children will also be saved.
+
+        Args:
+            name(: obj: `str`, optional): A name for the registered class .
+                If None, the class name will be used.
+            bases(tuple): ???.
+            attrs dict[str, str]: object attributes dictionnary.
+
+        Return:
+            type[object]: returns the given class as input.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def register(
+        cls,
+        name: str | None = None,
+    ) -> Callable[[type[object]], type[object]]:
+        """Function using a wrapper to register the given class with a specific name."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get(cls, name: str) -> type[object] | None:
+        """Returns the saved classe with a given name as key."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def all(cls) -> dict[str, type[object]]:
+        """Return all the saved classes."""
+        raise NotImplementedError
+
+
+class BaseRegistry(type, AbstractRegistry):
     """A generic registry implementation.
 
-    #registry-subclasses.
-    Source: https://charlesreid1.github.io/python-patterns-the-registry.html
+    # registry-subclasses.
+    Source: https: // charlesreid1.github.io/python-patterns-the-registry.html
     """
 
     _REGISTRY: ClassVar[dict[str, type[object]]] = {}
@@ -24,9 +73,9 @@ class BaseRegistry(type):
         registry and all children will also be saved.
 
         Args:
-            name (:obj:`str`, optional): A name for the registered class.
+            name(: obj: `str`, optional): A name for the registered class .
                 If None, the class name will be used.
-            bases (tuple): ???.
+            bases(tuple): ???.
             attrs dict[str, str]: object attributes dictionnary.
 
         Return:

--- a/src/stimulus/data/splitters/__init__.py
+++ b/src/stimulus/data/splitters/__init__.py
@@ -1,0 +1,1 @@
+"""Splitter register."""

--- a/src/stimulus/data/splitters/registry.py
+++ b/src/stimulus/data/splitters/registry.py
@@ -34,8 +34,7 @@ class SplitterRegistry(AbstractRegistry):
     def _check_class(cls, class_to_register: AbstractSplitter) -> None:
         # Check if class_to_register is a type
         if not isinstance(class_to_register, type):
-            raise TypeError(
-                f"{class_to_register} must be a class, not an instance")
+            raise TypeError(f"{class_to_register} must be a class, not an instance")
 
         if not issubclass(type(class_to_register), type(cls._CLASS_TYPE)):
             raise TypeError(

--- a/src/stimulus/data/splitters/registry.py
+++ b/src/stimulus/data/splitters/registry.py
@@ -5,59 +5,39 @@ metaclass=SplitterRegistry in a new object or using the wrapper
 function as a header `@SplitterRegistry.register(name)`
 """
 
-from abc import ABCMeta
+from typing import ClassVar
+
 from src.stimulus.core.registry import AbstractRegistry
 from src.stimulus.data.splitting.splitters import AbstractSplitter
-from typing import Any, ClassVar
 
 
-class SplitterRegistry(AbstractRegistry, ABCMeta):
-    """
-    A specific registry for splitters.
+class SplitterRegistry(AbstractRegistry):
+    """A specific registry for splitters.
 
     ABC meta is needed here as AbstractRegistry implements ABC and uses @abstractmethod
     """
 
     _REGISTRY: ClassVar[dict[str, AbstractSplitter]] = {}
-    _CLASS_TYPE: AbstractRegistry = AbstractRegistry
+    _CLASS_TYPE: object = AbstractSplitter
 
     @classmethod
-    def _check_class(cls, class_to_register):
+    def save_class(
+        cls,
+        class_to_register: AbstractSplitter,
+        name: str | None = None,
+    ) -> None:
+        """Checks for the right class and saves it if class correct."""
+        cls._check_class(class_to_register)
+        super().save_class(class_to_register=class_to_register, name=name)
+
+    @classmethod
+    def _check_class(cls, class_to_register: AbstractSplitter) -> None:
         # Check if class_to_register is a type
         if not isinstance(class_to_register, type):
             raise TypeError(
                 f"{class_to_register} must be a class, not an instance")
 
-        # Use try-except to handle potential errors
-        try:
-            if not issubclass(type(class_to_register), type(cls._CLASS_TYPE)):
-                raise TypeError(
-                    f"{cls._CLASS_TYPE} must be subclass of {class_to_register}"
-                )
-        except TypeError as e:
-            print(f"Error during subclass check: {e}")
-            # If there's an error, assume it's not a subclass
+        if not issubclass(type(class_to_register), type(cls._CLASS_TYPE)):
             raise TypeError(
-                f"{class_to_register} must be subclass of \
-                {cls._CLASS_TYPE.__name__}"
+                f"{cls._CLASS_TYPE} must be subclass of {class_to_register}",
             )
-
-    def __new__(
-        cls, name: str, bases: tuple, attrs: dict[str, Any]
-    ) -> AbstractSplitter:
-        """
-        cls: Class to register
-        name: The name of the class that is registered (that inherits from SplitterRegistry).
-        bases: The other base class from which the registered class inherits.
-        attrs: The registered class attributes.
-        """
-        new_splitter: AbstractSplitter = type.__new__(cls, name, bases, attrs)
-        cls.save_class(new_splitter, name)
-        return new_splitter
-
-    @classmethod
-    def save_class(
-        cls, class_to_register: AbstractSplitter, name: str | None = None
-    ) -> None:
-        cls._check_class(class_to_register)
-        super().save_class(class_to_register=class_to_register, name=name)

--- a/src/stimulus/data/splitters/registry.py
+++ b/src/stimulus/data/splitters/registry.py
@@ -1,0 +1,63 @@
+"""A registry object for Splitter objects.
+
+This registry can add a class to the registry either by using
+metaclass=SplitterRegistry in a new object or using the wrapper
+function as a header `@SplitterRegistry.register(name)`
+"""
+
+from abc import ABCMeta
+from src.stimulus.core.registry import AbstractRegistry
+from src.stimulus.data.splitting.splitters import AbstractSplitter
+from typing import Any, ClassVar
+
+
+class SplitterRegistry(AbstractRegistry, ABCMeta):
+    """
+    A specific registry for splitters.
+
+    ABC meta is needed here as AbstractRegistry implements ABC and uses @abstractmethod
+    """
+
+    _REGISTRY: ClassVar[dict[str, AbstractSplitter]] = {}
+    _CLASS_TYPE: AbstractRegistry = AbstractRegistry
+
+    @classmethod
+    def _check_class(cls, class_to_register):
+        # Check if class_to_register is a type
+        if not isinstance(class_to_register, type):
+            raise TypeError(
+                f"{class_to_register} must be a class, not an instance")
+
+        # Use try-except to handle potential errors
+        try:
+            if not issubclass(type(class_to_register), type(cls._CLASS_TYPE)):
+                raise TypeError(
+                    f"{cls._CLASS_TYPE} must be subclass of {class_to_register}"
+                )
+        except TypeError as e:
+            print(f"Error during subclass check: {e}")
+            # If there's an error, assume it's not a subclass
+            raise TypeError(
+                f"{class_to_register} must be subclass of \
+                {cls._CLASS_TYPE.__name__}"
+            )
+
+    def __new__(
+        cls, name: str, bases: tuple, attrs: dict[str, Any]
+    ) -> AbstractSplitter:
+        """
+        cls: Class to register
+        name: The name of the class that is registered (that inherits from SplitterRegistry).
+        bases: The other base class from which the registered class inherits.
+        attrs: The registered class attributes.
+        """
+        new_splitter: AbstractSplitter = type.__new__(cls, name, bases, attrs)
+        cls.save_class(new_splitter, name)
+        return new_splitter
+
+    @classmethod
+    def save_class(
+        cls, class_to_register: AbstractSplitter, name: str | None = None
+    ) -> None:
+        cls._check_class(class_to_register)
+        super().save_class(class_to_register=class_to_register, name=name)

--- a/tests/core/mock.py
+++ b/tests/core/mock.py
@@ -1,8 +1,8 @@
 """A mock class to show the registering on import in tests/core/test_registry.py."""
 
 from src.stimulus.core.registry import BaseRegistry
-from src.stimulus.data.splitting.splitters import AbstractSplitter
 from src.stimulus.data.splitters.registry import SplitterRegistry
+from src.stimulus.data.splitting.splitters import AbstractSplitter
 
 
 @BaseRegistry.register("tEst_ClAss3")
@@ -14,8 +14,8 @@ class Class3:
         return "class3"
 
 
-@SplitterRegistry.register("tEst_ClAss3")
-class Class3(AbstractSplitter):
+@SplitterRegistry.register("SplitTER_ClAss3")
+class Splitter3(AbstractSplitter):
     """A mock class."""
 
     def echo(self) -> str:

--- a/tests/core/mock.py
+++ b/tests/core/mock.py
@@ -1,6 +1,8 @@
 """A mock class to show the registering on import in tests/core/test_registry.py."""
 
 from src.stimulus.core.registry import BaseRegistry
+from src.stimulus.data.splitting.splitters import AbstractSplitter
+from src.stimulus.data.splitters.registry import SplitterRegistry
 
 
 @BaseRegistry.register("tEst_ClAss3")
@@ -10,3 +12,12 @@ class Class3:
     def echo(self) -> str:
         """Returns just class3."""
         return "class3"
+
+
+@SplitterRegistry.register("tEst_ClAss3")
+class Class3(AbstractSplitter):
+    """A mock class."""
+
+    def echo(self) -> str:
+        """Returns just class3."""
+        return "splitter_3"

--- a/tests/data/splitters/__init__.py
+++ b/tests/data/splitters/__init__.py
@@ -1,0 +1,1 @@
+"""Splitter registry test package."""

--- a/tests/data/splitters/test_splitter_registry.py
+++ b/tests/data/splitters/test_splitter_registry.py
@@ -1,0 +1,62 @@
+"""Test for the Splitter Registry class."""
+
+import pytest
+
+from src.stimulus.core.registry import BaseRegistry
+from src.stimulus.data.splitting import AbstractSplitter
+from src.stimulus.data.splitters.registry import SplitterRegistry
+from tests.core import mock
+
+
+class SplitterClass(AbstractSplitter, metaclass=SplitterRegistry):
+    """Base Splitter test class."""
+
+    def __init__(self) -> None:
+        """Initializes the base splitter class that should be registered for the metaclass."""
+        self.base: str = "class"
+        self.name: str = "splitter"
+
+    def echo(self) -> str:
+        """Returns the base + _ + name attributes."""
+        return self.base + "_" + self.name
+
+
+# Defining a class that inherits from base_test_class.
+# It will also be added to the registry automatically due
+# to its inheritance
+class SplitterClass1(SplitterClass):
+    """Child class of SplitterTestClass, registered through it's inheritance."""
+
+    def __init__(self) -> None:
+        """Init the parent class to get its attributes and the child class."""
+        super().__init__()
+        self.name = "splitter_1"
+
+
+@SplitterRegistry.register("test_splitTer")
+class SplitterClass2(AbstractSplitter):
+    """A class that is manually registered in the registry with the header."""
+
+    def __init__(self) -> None:
+        """Defines only a name attribute."""
+        self.name: str = "splitter_2"
+
+    def echo(self) -> str:
+        """Returns the name attribute."""
+        return self.name
+
+
+def test_num_splitter_in_registry() -> None:
+    """Checks that SplitterClass, SplitterClass1, SplitterClass2."""
+    splitter_registry_classes: dict[str,
+                                    AbstractSplitter] = SplitterRegistry.all()
+    assert len(splitter_registry_classes) == 4
+
+
+def test_wrong_model_registering() -> None:
+    with pytest.raises(TypeError, match=".* must be subclass of"):
+
+        @SplitterRegistry.register("false_splitter")
+        class FalseSplitter:
+            def __init__():
+                pass

--- a/tests/data/splitters/test_splitter_registry.py
+++ b/tests/data/splitters/test_splitter_registry.py
@@ -1,11 +1,13 @@
 """Test for the Splitter Registry class."""
 
+from typing import Any
+
 import pytest
 
-from src.stimulus.core.registry import BaseRegistry
-from src.stimulus.data.splitting import AbstractSplitter
+from src.stimulus.core.registry import AbstractRegistry, BaseRegistry
 from src.stimulus.data.splitters.registry import SplitterRegistry
-from tests.core import mock
+from src.stimulus.data.splitting import AbstractSplitter
+from tests.core import mock  # noqa: F401
 
 
 class SplitterClass(AbstractSplitter, metaclass=SplitterRegistry):
@@ -48,15 +50,37 @@ class SplitterClass2(AbstractSplitter):
 
 def test_num_splitter_in_registry() -> None:
     """Checks that SplitterClass, SplitterClass1, SplitterClass2."""
-    splitter_registry_classes: dict[str,
-                                    AbstractSplitter] = SplitterRegistry.all()
+    splitter_registry_classes: dict[str, AbstractSplitter] = SplitterRegistry.all()
     assert len(splitter_registry_classes) == 4
 
 
+# We intentionnaly use the wrong type
 def test_wrong_model_registering() -> None:
+    """Checks that the model raisses an error on wrong class registering."""
     with pytest.raises(TypeError, match=".* must be subclass of"):
 
-        @SplitterRegistry.register("false_splitter")
+        @SplitterRegistry.register("false_splitter")  # noqa: arg-type
         class FalseSplitter:
-            def __init__():
+            """A class that should raise an error because it is not inheriting AbstractSplitter."""
+
+            def __init__(self):
                 pass
+
+
+def test_uniqueness_registry() -> None:
+    """Checks that registering in the SplitterRegistry doesn't save in the BaseRegistry."""
+    splitter_registry_classes: dict[str, AbstractSplitter] = SplitterRegistry.all()
+    base_registry_classes: dict[str, Any] = BaseRegistry.all()
+    abstract_registry_classes: dict[str, Any] = AbstractRegistry.all()
+
+    # Generate set to get unique objects and do faster comparison
+    splitter_registry_set: set[AbstractSplitter] = set(
+        splitter_registry_classes.values(),
+    )
+    base_registry_set: set[Any] = set(base_registry_classes.values())
+    abstract_registry_set: set[Any] = set(abstract_registry_classes.values())
+
+    # Check that there's no intersection between them
+    assert len(splitter_registry_set.intersection(base_registry_set)) == 0
+    assert len(splitter_registry_set.intersection(abstract_registry_set)) == 0
+    assert len(base_registry_set.intersection(abstract_registry_set)) == 0


### PR DESCRIPTION
Few changes:
- Added an AbstractRegistry: it holds most of the logic common to all the registries.
    - Each registry object needs to declare his own _REGISTRY attribute
    - Each registry can then implement his own saving logic and checking logic to check for the right type of object
    - It inherits from ABCMeta to be able to be parent of classes having an Abstract parent like AbstractSplitter. ABCMeta implements type object so it can also be a metaclass
- BaseRegistry inherits now from AbstractRegistry
- SplitterRegistry has his own saving logic that checks that the saved unitiliazed objects are inheriting from AbstractSplitter